### PR TITLE
문제목록 페이지 원인 해결(빈 카드 삽입이 원인)

### DIFF
--- a/src/pages/CardList/components/CardListContainer.tsx
+++ b/src/pages/CardList/components/CardListContainer.tsx
@@ -22,7 +22,7 @@ export interface CardData {
   tags: string[];
   checked: boolean;
   description: string;
-  CardTitle: string;
+  ProblemTitle: string;
 }
 
 type CardSwiperProps = React.ComponentProps<'h2'> & {
@@ -64,7 +64,7 @@ const CardListContainer: React.FC<CardSwiperProps> = ({
         userName: item.users.nickname,
         tags: Object.values(item.tags!),
         checked: false,
-        CardTitle: item.CardTitle,
+        ProblemTitle: item.problemTitle,
         description: item.desc,
       }));
 
@@ -141,7 +141,7 @@ const CardListContainer: React.FC<CardSwiperProps> = ({
                   checked={item.checked}
                   description={item.description}
                 >
-                  {item.CardTitle}
+                  {item.ProblemTitle}
                 </Card>
               </SwiperSlide>
             ))}


### PR DESCRIPTION
## PR 유형
- [] 새로운 기능 추가
- [x] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
- 페이지네이션이 이상하게 나오는 문제 해결
(원인) '클릭해서 카드 만들기'라는 카드를 카드들 끝에 넣으려고 했음. 카드 스와이퍼에서 만들었던 방식과 동일하게. 문제는, 얘는 페이지네이션 컴포넌트가 연결되어있었다는 거임. 그냥 끝에 넣는 게 되버림. 그래서, 페이지를 계산해서 (전체 카드 갯수를 12개로 나눠서) 끝 페이지의 끝에만 삽입되도록 함. 콜백을 사용한 방식이 문제인 줄 알고 과거 코드 끌고와서 하나하나 고치고 있었는데............ 허무하게 해결.

## 이슈
<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #151 
